### PR TITLE
Fix: ensure non-null collections for API schema properties

### DIFF
--- a/src/main/java/com/ly/doc/model/ApiSchema.java
+++ b/src/main/java/com/ly/doc/model/ApiSchema.java
@@ -21,6 +21,7 @@
 
 package com.ly.doc.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -37,6 +38,9 @@ public class ApiSchema<T> {
     private List<ApiExceptionStatus> apiExceptionStatuses;
 
     public List<T> getApiDatas() {
+        if (apiDatas == null) {
+            apiDatas = new ArrayList<>();
+        }
         return apiDatas;
     }
 
@@ -45,6 +49,9 @@ public class ApiSchema<T> {
     }
 
     public List<ApiExceptionStatus> getApiExceptionStatuses() {
+        if (apiExceptionStatuses == null) {
+            apiExceptionStatuses = new ArrayList<>();
+        }
         return apiExceptionStatuses;
     }
 

--- a/src/main/java/com/ly/doc/template/IDocBuildTemplate.java
+++ b/src/main/java/com/ly/doc/template/IDocBuildTemplate.java
@@ -29,6 +29,7 @@ import com.thoughtworks.qdox.model.JavaClass;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author yu 2019/12/21.
@@ -46,12 +47,15 @@ public interface IDocBuildTemplate<T extends IDoc> extends IDocBuildBaseTemplate
         DocMapping.init();
         DocBuildHelper docBuildHelper = DocBuildHelper.create(projectBuilder);
 
-        preRender(docBuildHelper);
+        this.preRender(docBuildHelper);
         // get candidate classes
-        Collection<JavaClass> candidateClasses = getCandidateClasses(projectBuilder, docBuildHelper);
-        ApiSchema<T> apiSchema = renderApi(projectBuilder, candidateClasses);
+        Collection<JavaClass> candidateClasses = this.getCandidateClasses(projectBuilder, docBuildHelper);
+        ApiSchema<T> apiSchema = this.renderApi(projectBuilder, candidateClasses);
 
-        postRender(docBuildHelper, apiSchema.getApiDatas());
+        if (Objects.isNull(apiSchema)) {
+            return new ApiSchema<>();
+        }
+        this.postRender(docBuildHelper, apiSchema.getApiDatas());
 
         return apiSchema;
     }
@@ -65,8 +69,6 @@ public interface IDocBuildTemplate<T extends IDoc> extends IDocBuildBaseTemplate
      * @return api ApiSchema
      */
     ApiSchema<T> renderApi(ProjectDocConfigBuilder projectBuilder, Collection<JavaClass> candidateClasses);
-
-
 
 
     /**


### PR DESCRIPTION
ApiSchema.java and IDocBuildTemplate.java have been updated to initialize
apiDatas and apiExceptionStatuses collections to prevent null pointer
exceptions. Additionally, postRender method in IDocBuildTemplate.java nowchecks for null apiSchema before processing, enhancing the robustness of
the documentation build process.