### PR TITLE
fix: retain query parameters when ContentType is multipart/form-data

### DIFF
--- a/src/main/java/com/ly/doc/model/torna/Apis.java
+++ b/src/main/java/com/ly/doc/model/torna/Apis.java
@@ -18,61 +18,151 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.ly.doc.model.torna;
 
+import com.ly.doc.model.ApiMethodDoc;
+
+import java.io.Serializable;
 import java.util.List;
 
 /**
+ * Torna Api DocItem(cn.torna.sdk.param.DocItem)
+ *
  * @author xingzi 2021/2/8 10:07
+ * @since 2.0.9
  **/
-public class Apis {
+public class Apis implements Serializable {
 
+	private static final long serialVersionUID = 603355518657235962L;
+
+	/**
+	 * api doc name
+	 */
 	private String name;
 
+	/**
+	 * api doc description
+	 */
 	private String description;
 
+	/**
+	 * api doc url
+	 */
 	private String url;
 
+	/**
+	 * http method
+	 */
 	private String httpMethod;
 
+	/**
+	 * content type
+	 */
 	private String contentType;
 
+	/**
+	 * is folder
+	 * @see com.ly.doc.constants.TornaConstants#YES
+	 * @see com.ly.doc.constants.TornaConstants#NO
+	 */
 	private String isFolder;
 
+	/**
+	 * parent id
+	 */
 	private String parentId;
 
+	/**
+	 * is show
+	 * @see com.ly.doc.constants.TornaConstants#YES
+	 * @see com.ly.doc.constants.TornaConstants#NO
+	 */
 	private String isShow;
 
+	/**
+	 * author
+	 */
 	private String author;
 
+	/**
+	 * order index
+	 */
 	private Integer orderIndex;
 
+	/**
+	 * dubbo info
+	 */
 	private DubboInfo dubboInfo;
 
+	/**
+	 * header params
+	 * @see ApiMethodDoc#getRequestHeaders()
+	 */
 	private List<HttpParam> headerParams;
 
+	/**
+	 * path params
+	 * @see ApiMethodDoc#getPathParams()
+	 */
 	private List<HttpParam> pathParams;
 
+	/**
+	 * query params
+	 * @see ApiMethodDoc#getQueryParams()
+	 */
 	private List<HttpParam> queryParams;
 
+	/**
+	 * request params; body params
+	 * @see ApiMethodDoc#getRequestParams()
+	 */
 	private List<HttpParam> requestParams;
 
+	/**
+	 * response params
+	 * @see ApiMethodDoc#getResponseParams()
+	 */
 	private List<HttpParam> responseParams;
 
+	/**
+	 * error code params
+	 */
 	private String errorCodeParams;
 
+	/**
+	 * items
+	 */
 	private List<Apis> items;
 
+	/**
+	 * is request array
+	 */
 	private Integer isRequestArray;
 
+	/**
+	 * request array type object/number/string/boolean
+	 */
 	private String requestArrayType;
 
+	/**
+	 * is response array
+	 */
 	private Integer isResponseArray;
 
+	/**
+	 * response array type object/number/string/boolean
+	 */
 	private String responseArrayType;
 
+	/**
+	 * deprecated
+	 */
 	private String deprecated;
 
+	/**
+	 * version
+	 */
 	private String version;
 
 	public String getVersion() {

--- a/src/main/java/com/ly/doc/model/torna/DubboInfo.java
+++ b/src/main/java/com/ly/doc/model/torna/DubboInfo.java
@@ -21,19 +21,44 @@
 
 package com.ly.doc.model.torna;
 
-/**
- * @author xingzi 2021/4/28 12:54
- **/
-public class DubboInfo {
+import java.io.Serializable;
 
+/**
+ * Torna Dubbo Info
+ *
+ * @author xingzi 2021/4/28 12:54
+ * @since 2.1.5
+ **/
+public class DubboInfo implements Serializable {
+
+	/**
+	 * serialVersionUID
+	 */
+	private static final long serialVersionUID = 1556292473952962536L;
+
+	/**
+	 * dubbo interface name
+	 */
 	private String interfaceName;
 
+	/**
+	 * author
+	 */
 	private String author;
 
+	/**
+	 * dubbo interface version
+	 */
 	private String version;
 
+	/**
+	 * dubbo protocol
+	 */
 	private String protocol;
 
+	/**
+	 * dubbo maven dependency
+	 */
 	private String dependency;
 
 	public DubboInfo builder() {

--- a/src/main/java/com/ly/doc/utils/TornaUtil.java
+++ b/src/main/java/com/ly/doc/utils/TornaUtil.java
@@ -28,7 +28,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.ly.doc.constants.DocAnnotationConstants;
 import com.ly.doc.constants.DocGlobalConstants;
-import com.ly.doc.constants.MediaType;
 import com.ly.doc.constants.ParamTypeConstants;
 import com.ly.doc.constants.TornaConstants;
 import com.ly.doc.model.ApiConfig;
@@ -244,20 +243,15 @@ public class TornaUtil {
 			methodApi.setRequestArrayType(apiMethodDoc.getRequestArrayType());
 			methodApi.setResponseArrayType(apiMethodDoc.getResponseArrayType());
 			methodApi.setDeprecated(apiMethodDoc.isDeprecated() ? DocAnnotationConstants.DEPRECATED : null);
-			// Path
+			// Path Param
 			if (CollectionUtil.isNotEmpty(apiMethodDoc.getPathParams())) {
 				methodApi.setPathParams(buildParams(apiMethodDoc.getPathParams()));
 			}
-
-			if (CollectionUtil.isNotEmpty(apiMethodDoc.getQueryParams())
-					&& MediaType.MULTIPART_FORM_DATA.equals(apiMethodDoc.getContentType())) {
-				// file upload
-				methodApi.setRequestParams(buildParams(apiMethodDoc.getQueryParams()));
-			}
-			else if (CollectionUtil.isNotEmpty(apiMethodDoc.getQueryParams())) {
+			// Query Param
+			if (CollectionUtil.isNotEmpty(apiMethodDoc.getQueryParams())) {
 				methodApi.setQueryParams(buildParams(apiMethodDoc.getQueryParams()));
 			}
-			// Json
+			// Body Param
 			if (CollectionUtil.isNotEmpty(apiMethodDoc.getRequestParams())) {
 				methodApi.setRequestParams(buildParams(apiMethodDoc.getRequestParams()));
 			}


### PR DESCRIPTION
Resolved an issue where query parameters (annotated with `@RequestParam`) were lost when the ContentType was set to multipart/form-data and pushed to Torna.
- Added logic to properly handle and set query parameters in TornaUtil.
- Ensured all parameter types (Path, Query, Body) are correctly processed and included.
