### PR TITLE
docs(contributing): add Angular commit convention guidelines

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -18,6 +18,18 @@ jobs:
           repository: ${{ github.repository }}
           issue-number: ${{ github.event.number }}
           body: |
+            @${{ github.event.pull_request.user.login }}
+            
+            🔍 **Before proceeding, please review the contribution guidelines**  
+            - [📖 Contribution Guide](https://github.com/smart-doc-group/smart-doc/blob/master/CONTRIBUTING.md)
+            
+            This includes requirements for:  
+            - ✅ Commit message format (Angular Convention. `feat`, `fix`, etc.)  
+            - 🧹 Code style (execute `mvn spring-javaformat:apply`)   
+            - 📄 Documentation updates (if config changes)   
+            - 💡 Example code submission (for new features)
+            
+            
             Thanks for your PR. :pray: 
             Please check again for your PR changes whether they contain any usage configuration change, such as `Add new configuration` or `Change default value of configuration`.
             If so, please add or update documents (Markdown format) in the `docs/` directory of the repository [smart-doc-group/smart-doc-group.github.io](https://github.com/smart-doc-group/smart-doc-group.github.io/tree/master/docs).
@@ -28,6 +40,16 @@ jobs:
             The code should use the Spring code style. Please format your code using the command `mvn spring-javaformat:apply`. You can also install the [Spring Java Format](https://github.com/spring-io/spring-javaformat) plugin for convenience.
             
             ---
+            
+            
+            🔍 **提交前请务必完成以下检查**  
+            - [📘 贡献指南](https://github.com/smart-doc-group/smart-doc/blob/master/CONTRIBUTING_CN.md)
+            
+            需特别注意：  
+            - ✅ 提交信息格式 (`feat`, `fix` 等类型)  
+            - 🧹 代码风格（执行 `mvn spring-javaformat:apply`）  
+            - 📄 文档更新（配置变更需同步更新 docs）  
+            - 💡 示例代码（新功能需提供示例）  
             
             感谢您提交的PR。 :pray: 
             请再次查看您的PR内容，确认是否包含任何使用方式或配置参数的变更，如：`新增配置参数`、`修改默认配置`等操作。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@ Before submitting a Pull Request (PR), please ensure:
 - 🌍 **English comments**: Use English for code comments to support international collaboration.
 - ✅ **Code quality**: Follow the [Spring Java Format](https://github.com/spring-io/java-format) style and add unit tests.
 - 📄 **Update documentation**: Reflect your changes in relevant documentation [`smart-doc-group.github.io`](https://github.com/smart-doc-group/smart-doc-group.github.io/tree/master/docs). if needed.
+- 📝 **Commit message guidelines**: All commits must follow the [Angular Commit Convention](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit).
+	- Use appropriate types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, etc.
+	- Keep subject and body concise, avoiding vague terms like "update code".
+	- Reference related issues (e.g., `Closes #1234`) in the footer when applicable.
 
 ## Documentation and Examples
 If your contribution involves:

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -9,6 +9,10 @@
 - 🌍 **英文注释**：代码注释使用英文，支持国际化协作。
 - ✅ **代码质量**：遵循 [Spring Java Format](https://github.com/spring-io/java-format) 风格，添加单元测试。
 - 📄 **文档同步更新**：若涉及功能变更，请同步更新 [`smart-doc-group.github.io`](https://github.com/smart-doc-group/smart-doc-group.github.io/tree/master/docs) 文档。
+- 📝 **提交信息规范**：所有提交需严格遵循 [Angular 提交规范](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)。
+	- 使用标准类型：`feat`（新功能）、`fix`（修复）、`docs`（文档）、`style`（格式调整）、`refactor`（重构）、`test`（测试）、`chore`（构建/依赖管理）等。
+	- 主题与正文需简洁明确，避免“更新代码”等模糊描述。
+	- 若关联 Issue，需在页脚注明（如 `Closes #1234`）。
 
 ## 文档与示例要求
 若贡献包含以下内容：


### PR DESCRIPTION
- Update CONTRIBUTING.md and CONTRIBUTING_CN.md with commit message guidelines
- Introduce Angular Commit Convention for improved commit clarity and consistency
- Emphasize concise and descriptive commit messages
- Encourage referencing related issues in commit footers